### PR TITLE
fix usleep undeclaration under Linux and add OpenGL linker flag to Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.o
+
+CameraCalibrator
+PTAM

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # Or to change the compiler's optimization flags
 CC = g++
 COMPILEFLAGS = ${CPPFLAGS} -D_LINUX -D_REENTRANT -Wall  -O3 -march=nocona -msse3
-LINKFLAGS = ${LDFLAGS}  -lblas -llapack -lGVars3 -lcvd
+LINKFLAGS = ${LDFLAGS}  -lblas -llapack -lGVars3 -lcvd -lGL -lGLU 
 
 # add OpenCV dependencies
 COMPILEFLAGS += $(shell pkg-config --cflags opencv)

--- a/Tracker.cc
+++ b/Tracker.cc
@@ -1,4 +1,6 @@
 // Copyright 2008 Isis Innovation Limited
+#include <unistd.h>
+
 #include "OpenGL.h"
 #include "Tracker.h"
 #include "MEstimator.h"

--- a/VideoSource_Linux_OpenCV.cc
+++ b/VideoSource_Linux_OpenCV.cc
@@ -23,6 +23,7 @@
 #include <opencv/highgui.h>
 #include <opencv/cxcore.h>
 #include <opencv/cv.h>
+#include "opencv2/opencv.hpp"
 
 using namespace CVD;
 using namespace std;

--- a/VideoSource_Linux_OpenCV.cc
+++ b/VideoSource_Linux_OpenCV.cc
@@ -20,10 +20,7 @@
 #include <cvd/colourspace_convert.h>
 #include <cvd/colourspaces.h>
 #include <gvars3/instances.h>
-#include <opencv/highgui.h>
-#include <opencv/cxcore.h>
-#include <opencv/cv.h>
-#include "opencv2/opencv.hpp"
+#include "opencv2/highgui.hpp"
 
 using namespace CVD;
 using namespace std;


### PR DESCRIPTION
Hello there,

  Appreciate the effort to put OpenCV and Gstreamer support to PTAM, while trying to compile the source code under Fedora 20, got two small issues described in the title. This pull-request will get them fixed.

  Also, I add a `.gitignore` file to drop the compiled the files out of the source code files.

Lihang
